### PR TITLE
Add edge auth proxy and update rewrites

### DIFF
--- a/api/auth-login.ts
+++ b/api/auth-login.ts
@@ -1,0 +1,26 @@
+export const config = {
+  runtime: 'edge',
+};
+
+export default async function handler(req: Request): Promise<Response> {
+  if (req.method !== 'POST') {
+    return new Response('Method Not Allowed', { status: 405 });
+  }
+
+  const backendResponse = await fetch(
+    'https://crossword-backend.onrender.com/login',
+    {
+      method: req.method,
+      headers: req.headers,
+      body: req.body,
+    }
+  );
+
+  const headers = new Headers(backendResponse.headers);
+  const body = backendResponse.body;
+  return new Response(body, {
+    status: backendResponse.status,
+    statusText: backendResponse.statusText,
+    headers,
+  });
+}

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -1,4 +1,4 @@
 export const environment = {
     production: true,
-    apiUrl: 'https://crossword-backend.onrender.com',
+    apiUrl: '/api',
 };

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -1,5 +1,5 @@
 export const environment = {
     production: false,
-    apiUrl: 'http://localhost:8080',
+    apiUrl: '/api',
     openaiApiKey: ''
-}; 
+};

--- a/vercel.json
+++ b/vercel.json
@@ -1,12 +1,7 @@
 {
   "rewrites": [
-    {
-      "source": "/api/(.*)",
-      "destination": "https://crossword-backend.onrender.com/$1"
-    },
-    {
-      "source": "/(.*)",
-      "destination": "/index.html"
-    }
+    { "source": "/api/login",  "destination": "/api/auth-login" },
+    { "source": "/api/(.*)",   "destination": "https://crossword-backend.onrender.com/$1" },
+    { "source": "/(.*)",       "destination": "/index.html" }
   ]
 }


### PR DESCRIPTION
## Summary
- implement /api/auth-login Edge function to proxy backend login
- rewrite /api/login to use new auth-login function
- use relative `/api` URL for API calls in all environments

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860afab4d448320a5553b68845305b8